### PR TITLE
Reverse dns for module name

### DIFF
--- a/.lift.toml
+++ b/.lift.toml
@@ -2,6 +2,10 @@ build = "mvn"
 
 jdk11 = true
 
+ignoreFiles = """
+src/test/
+"""
+
 # Ignore warnings not relevant to this specific project:
 #
 # 1) FindSecBugs identifies our use of ThreadLocalRandom as predictable.

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -37,7 +37,7 @@
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
  */
-module rho_mu {
+module org.cicirello.rho_mu {
 	exports org.cicirello.math;
 	exports org.cicirello.math.la;
 	exports org.cicirello.math.rand;


### PR DESCRIPTION
## Summary
Module name now uses reverse dns to avoid potential conflicts is users of library coincidentally use another library that may otherwise have the same name.
