### PR TITLE
Updated documentation website workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,6 +48,7 @@ jobs:
         base-url-path: https://rho-mu.cicirello.org/
         path-to-root: docs
         user-defined-block: |
+          <meta name="monetization" content="$ilp.uphold.com/RHNKxp4ZeLNE">
           <link rel="icon" href="/images/favicon.svg" sizes="any" type="image/svg+xml">
 
     - name: Log javadoc-cleanup output


### PR DESCRIPTION
## Summary
Updated the documentation website workflow to inject web monetization meta tag into the head of each javadoc page.
