### PR TITLE
Create .gitattributes to direct GitHub's Linguist to ignore paper directory

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+paper/* linguist-documentation


### PR DESCRIPTION
## Summary
Added .gitattributes to configure GitHub's Linguist which detects languages in a repository. It is currently detecting the bib file in the directory for JOSS paper submission as TeX (1.5% of repository detected as TeX in this way). I directed Linguist to treat the paper directory as documentation as far as language reporting is concerned, which will have the effect of ignoring that directory for GitHub's language distribution chart.
