### PR TITLE
Fixed javadoc warnings on example programs

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -190,6 +190,8 @@
 					</execution>
 				</executions>
 				<configuration>
+					<failOnWarnings>true</failOnWarnings>
+					<failOnError>true</failOnError>
 					<windowtitle>rho mu Example Programs</windowtitle>
 					<doctitle>rho mu Example Programs</doctitle>
 					<author>true</author>

--- a/examples/src/main/java/org/cicirello/examples/rho_mu/BasicUsageExamples.java
+++ b/examples/src/main/java/org/cicirello/examples/rho_mu/BasicUsageExamples.java
@@ -33,6 +33,9 @@ import java.util.Arrays;
  */
 public class BasicUsageExamples {
 	
+	/* private constructor to prevent instantiation */
+	private BasicUsageExamples() {}
+	
 	/**
 	 * Runs the example program.
 	 *

--- a/examples/src/main/java/org/cicirello/examples/rho_mu/ExamplesShared.java
+++ b/examples/src/main/java/org/cicirello/examples/rho_mu/ExamplesShared.java
@@ -26,6 +26,7 @@ package org.cicirello.examples.rho_mu;
  */
 public class ExamplesShared {
 	
+	/* private constructor to prevent instantiation */
 	private ExamplesShared() {}
 	
 	/**

--- a/examples/src/main/java/org/cicirello/examples/rho_mu/RandomIndexerTimes.java
+++ b/examples/src/main/java/org/cicirello/examples/rho_mu/RandomIndexerTimes.java
@@ -35,6 +35,9 @@ import org.cicirello.math.rand.RandomIndexer;
  */
 public class RandomIndexerTimes {
 	
+	/* private constructor to prevent instantiation */
+	private RandomIndexerTimes() {}
+	
 	// number of random numbers to generate for each time point
 	private final static int N = 2000000;
 	

--- a/examples/src/main/java/org/cicirello/examples/rho_mu/TimingNextBiasedIntMethod.java
+++ b/examples/src/main/java/org/cicirello/examples/rho_mu/TimingNextBiasedIntMethod.java
@@ -35,6 +35,9 @@ import org.cicirello.math.rand.RandomIndexer;
  */
 public class TimingNextBiasedIntMethod {
 	
+	/* private constructor to prevent instantiation */
+	private TimingNextBiasedIntMethod() {}
+	
 	// number of random numbers to generate for each time point
 	// NOTE: This is much higher than runs of basic nextInt timing comparison
 	// to get more easily measurable times for the nextBiasedInt method.


### PR DESCRIPTION
## Summary
Building the example programs was producing javadoc warnings, related to undocumented default constructors, as mentioned in https://github.com/openjournals/joss-reviews/issues/4663. Fixed by inserting private constructors since the example programs only have main methods and no reason to instantiate instances.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
