### PR TITLE
Add JOSS paper citation details to repository

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,5 +1,5 @@
 {
-    "title": "ρμ library",
+    "title": "ρμ: A Java library of randomization enhancements and other math utilities",
     "license": "GPL-3.0-or-later", 
     "upload_type": "software", 
     "creators": [

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,5 +1,5 @@
 {
-    "title": "ρμ: A Java library of randomization enhancements and other math utilities",
+    "title": "ρμ library",
     "license": "GPL-3.0-or-later", 
     "upload_type": "software", 
     "creators": [
@@ -20,5 +20,13 @@
 		"sampling",
 		"math utilities",
 		"Java"
-	]
+	],
+    "related_identifiers": [
+        {
+            "scheme": "doi",
+            "identifier": "10.21105/joss.04663",
+            "relation": "isDocumentedBy",
+            "resource_type": "publication"
+        }
+    ]
 }

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,23 @@
+cff-version: "1.1.0"
+message: "If you use this software, please cite it using these metadata."
+authors: 
+- family-names: "Cicirello"
+  given-names: "Vincent A"
+  orcid: "https://orcid.org/0000-0003-1072-8559"
+title: "ρμ: A Java library of randomization enhancements and other math utilities"
+doi: "10.5281/zenodo.5523173"
+license: "GPL-3.0-or-later"
+url: "https://github.com/cicirello/rho-mu"
+preferred-citation:
+  type: article
+  authors:
+  - family-names: "Cicirello"
+    given-names: "Vincent A"
+    orcid: "https://orcid.org/0000-0003-1072-8559"
+  doi: "10.21105/joss.04663"
+  journal: "Journal of Open Source Software"
+  start: 4663
+  title: "ρμ: A Java library of randomization enhancements and other math utilities"
+  issue: 76
+  volume: 7
+  year: 2022

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Website: https://rho-mu.cicirello.org/
 
 API documentation: https://rho-mu.cicirello.org/api/
 
-| | |
+| __Publications About the Library__ | [![DOI](https://joss.theoj.org/papers/10.21105/joss.04663/status.svg)](https://doi.org/10.21105/joss.04663) |
 | :--- | :--- |
 | __Packages and Releases__ | [![Maven Central](https://img.shields.io/maven-central/v/org.cicirello/rho-mu.svg?label=Maven%20Central&logo=apachemaven)](https://search.maven.org/artifact/org.cicirello/rho-mu) [![GitHub release (latest by date)](https://img.shields.io/github/v/release/cicirello/rho-mu?logo=GitHub)](https://github.com/cicirello/rho-mu/releases) [![JitPack](https://jitpack.io/v/org.cicirello/rho-mu.svg)](https://jitpack.io/#org.cicirello/rho-mu) |
 | __Build Status__ | [![build](https://github.com/cicirello/rho-mu/workflows/build/badge.svg)](https://github.com/cicirello/rho-mu/actions/workflows/build.yml) [![docs](https://github.com/cicirello/rho-mu/workflows/docs/badge.svg)](https://rho-mu.cicirello.org/api/) [![CodeQL](https://github.com/cicirello/rho-mu/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/cicirello/rho-mu/actions/workflows/codeql-analysis.yml) |
@@ -17,6 +17,12 @@ API documentation: https://rho-mu.cicirello.org/api/
 | __DOI__ | [![DOI](https://zenodo.org/badge/408560166.svg)](https://zenodo.org/badge/latestdoi/408560166) | 
 | __License__ | [![GitHub](https://img.shields.io/github/license/cicirello/rho-mu)](https://github.com/cicirello/rho-mu/blob/main/LICENSE) | 
 | __Support__ | [![GitHub Sponsors](https://img.shields.io/badge/sponsor-30363D?logo=GitHub-Sponsors&logoColor=#EA4AAA)](https://github.com/sponsors/cicirello) [![Liberapay](https://img.shields.io/badge/Liberapay-F6C915?logo=liberapay&logoColor=black)](https://liberapay.com/cicirello) [![Ko-Fi](https://img.shields.io/badge/Ko--fi-F16061?logo=ko-fi&logoColor=white)](https://ko-fi.com/cicirello) |
+
+## How to Cite
+
+If you use this library in your research, please cite the following paper:
+
+> Cicirello, V. A., (2022). ρμ: A Java library of randomization enhancements and other math utilities. *Journal of Open Source Software*, 7(76), 4663, https://doi.org/10.21105/joss.04663.
 
 ## Overview
 


### PR DESCRIPTION
## Summary
Add JOSS paper citation details to repository, including JOSS badge, how to cite, CITATION.cff, and metadata for JOSS paper in zenodo.json. 
