### PR TITLE
Improved ahead-of-time Jitpack builds for both snapshots and releases

### DIFF
--- a/.github/workflows/jitpack-build.yml
+++ b/.github/workflows/jitpack-build.yml
@@ -18,4 +18,4 @@ jobs:
     - name: Request main-SNAPSHOT from JitPack
       run: |
         # timeout in 30 seconds to avoid waiting for build
-        curl -s -m 30 https://jitpack.io/org/cicirello/rho-mu/main-SNAPSHOT/ || true
+        curl -s -m 30 https://jitpack.io/org/cicirello/rho-mu/main-SNAPSHOT/maven-metadata.xml || true

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -66,6 +66,6 @@ jobs:
 
     - name: Request release from JitPack to trigger build
       run: |
-        JITPACK_URL="https://jitpack.io/org/cicirello/rho-mu/${{ steps.get_version.outputs.VERSION }}/"
+        JITPACK_URL="https://jitpack.io/org/cicirello/rho-mu/${{ steps.get_version.outputs.VERSION }}/maven-metadata.xml"
         # timeout in 30 seconds to avoid waiting for build
         curl -s -m 30 ${JITPACK_URL} || true


### PR DESCRIPTION
## Summary
Improved ahead-of-time Jitpack builds both in the snapshot case, as well as for release tags, by curling maven-metadata.xml instead of the directory.

## Closing Issues
Closes #101 
Closes #102 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
