### PR TITLE
fix UML diagram width

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -125,7 +125,7 @@
  * corresponding to the wrapped random number generator instances.
  *
  * <p><object type="image/svg+xml" data="https://rho-mu.cicirello.org/images/rho-mu-uml.svg"
- * width="872" height="1038">UML diagram</object>
+ * width="882" height="1038">UML diagram</object>
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>


### PR DESCRIPTION
## Summary
Fixed the width of the UML diagram in the embedding in the javadoc comments to correspond to the width of the updated diagram.

## Closing Issues
Closes #125 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
