### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,13 @@
 version: 2
 updates:
-  - package-ecosystem: "maven" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "github-actions"
+    directory: "/"
     target-branch: "main"
     schedule:
       interval: "daily"
 
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: "maven" # See documentation for possible values
+    directory: "/" # Location of package manifests
     target-branch: "main"
     schedule:
       interval: "daily"


### PR DESCRIPTION
## Summary
Updated dependabot.yml with minor edits.... checking if changing order would resolve dependabot's refusal to check multiple pom.xml files despite docs claiming it will by using multiple entries for the same package manager. This PR puts the two maven entries one after the other.
