### PR TITLE
Deprecated ZigguratGaussian, in preparation for making it an internal package access class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 * Deprecated PolarGaussian, in preparation for future removal.
+* Deprecated ZigguratGaussian, in preparation for making it an internal package access class.
 
 ### Removed
 

--- a/src/main/java/org/cicirello/math/rand/ZigguratGaussian.java
+++ b/src/main/java/org/cicirello/math/rand/ZigguratGaussian.java
@@ -7,7 +7,7 @@
  * Modifications made to port to the Java language are subject to
  * the following copyright and license:
  *
- * Copyright 2015-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * Copyright 2015-2024 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * ZigguratGaussian.java is free software: you can
  * redistribute it and/or modify it under the terms of the GNU
@@ -95,9 +95,13 @@ import java.util.random.RandomGenerator;
  *       Generating Gaussian Random Numbers</a>. GSL: GNU Scientific Library. 2005.
  * </ul>
  *
+ * @deprecated This class will become an internal package-access class. You should begin using the
+ *     corresponding static methods of the {@link RandomVariates} class, or the instance methods of
+ *     the {@link EnhancedRandomGenerator} class.
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
  */
+@Deprecated
 public final class ZigguratGaussian {
 
   /*

--- a/src/test/java/org/cicirello/math/rand/ZigguratGaussianTests.java
+++ b/src/test/java/org/cicirello/math/rand/ZigguratGaussianTests.java
@@ -1,7 +1,7 @@
 /*
  * JUnit test cases for ZigguratGaussian.
  *
- * Copyright 2019-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * Copyright 2019-2024 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * The JUnit test cases for ZigguratGaussian is free software: you can
  * redistribute it and/or modify it under the terms of the GNU
@@ -29,6 +29,7 @@ import java.util.SplittableRandom;
 import org.junit.jupiter.api.*;
 
 /** JUnit test cases for the methods of the ZigguratGaussian class. */
+@SuppressWarnings("deprecated")
 public class ZigguratGaussianTests {
 
   // Test cases use chi square goodness of fit.  This constant


### PR DESCRIPTION
## Summary
Deprecated ZigguratGaussian, in preparation for making it an internal package access class.

## Closing Issues
Closes #255 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
