### PR TITLE
Update documentation to reference the SPE 2024 article

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
       if: ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}
       run: |
         rm -rf docs/api
-        cp -rf target/site/apidocs/. docs/api	
+        cp -rf target/reports/apidocs/. docs/api	
 
     - name: Tidy up the javadocs
       if: ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}

--- a/src/main/java/org/cicirello/math/rand/EnhancedRandomGenerator.java
+++ b/src/main/java/org/cicirello/math/rand/EnhancedRandomGenerator.java
@@ -478,10 +478,11 @@ public class EnhancedRandomGenerator implements RandomGenerator {
    *
    * <p>The runtime of this method is O(1), and it uses an algorithm described in:
    *
-   * <p>Vincent A. Cicirello. 2024. <a href="https://reports.cicirello.org/24/008/">Algorithms for
-   * Generating Small Random Samples. <a
-   * href="https://arxiv.org/abs/2405.12371">arXiv:2405.12371</a>, May 2024. <a
-   * href="https://reports.cicirello.org/24/008/ALG-24-008.pdf">[PDF]</a>
+   * <p>Vincent A. Cicirello. 2024. <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.html">Algorithms for Generating
+   * Small Random Samples.</a> <i>Software: Practice and Experience</i>, September 2024. doi:<a
+   * href="https://doi.org/10.1002/spe.3379">10.1002/spe.3379</a> <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.pdf">[PDF]</a>
    *
    * @param n The number of integers to choose from.
    * @param result An array to hold the pair that is generated. If result is null or if
@@ -499,10 +500,11 @@ public class EnhancedRandomGenerator implements RandomGenerator {
    *
    * <p>The runtime of this method is O(1), and it uses an algorithm described in:
    *
-   * <p>Vincent A. Cicirello. 2024. <a href="https://reports.cicirello.org/24/008/">Algorithms for
-   * Generating Small Random Samples. <a
-   * href="https://arxiv.org/abs/2405.12371">arXiv:2405.12371</a>, May 2024. <a
-   * href="https://reports.cicirello.org/24/008/ALG-24-008.pdf">[PDF]</a>
+   * <p>Vincent A. Cicirello. 2024. <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.html">Algorithms for Generating
+   * Small Random Samples.</a> <i>Software: Practice and Experience</i>, September 2024. doi:<a
+   * href="https://doi.org/10.1002/spe.3379">10.1002/spe.3379</a> <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.pdf">[PDF]</a>
    *
    * @param n The number of integers to choose from.
    * @return A pair of randomly chosen integers from the interval [0, n).
@@ -518,10 +520,11 @@ public class EnhancedRandomGenerator implements RandomGenerator {
    *
    * <p>The runtime of this method is O(1), and it uses an algorithm described in:
    *
-   * <p>Vincent A. Cicirello. 2024. <a href="https://reports.cicirello.org/24/008/">Algorithms for
-   * Generating Small Random Samples. <a
-   * href="https://arxiv.org/abs/2405.12371">arXiv:2405.12371</a>, May 2024. <a
-   * href="https://reports.cicirello.org/24/008/ALG-24-008.pdf">[PDF]</a>
+   * <p>Vincent A. Cicirello. 2024. <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.html">Algorithms for Generating
+   * Small Random Samples.</a> <i>Software: Practice and Experience</i>, September 2024. doi:<a
+   * href="https://doi.org/10.1002/spe.3379">10.1002/spe.3379</a> <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.pdf">[PDF]</a>
    *
    * @param n The number of integers to choose from.
    * @param result An array to hold the triple that is generated. If result is null or if
@@ -539,10 +542,11 @@ public class EnhancedRandomGenerator implements RandomGenerator {
    *
    * <p>The runtime of this method is O(1), and it uses an algorithm described in:
    *
-   * <p>Vincent A. Cicirello. 2024. <a href="https://reports.cicirello.org/24/008/">Algorithms for
-   * Generating Small Random Samples. <a
-   * href="https://arxiv.org/abs/2405.12371">arXiv:2405.12371</a>, May 2024. <a
-   * href="https://reports.cicirello.org/24/008/ALG-24-008.pdf">[PDF]</a>
+   * <p>Vincent A. Cicirello. 2024. <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.html">Algorithms for Generating
+   * Small Random Samples.</a> <i>Software: Practice and Experience</i>, September 2024. doi:<a
+   * href="https://doi.org/10.1002/spe.3379">10.1002/spe.3379</a> <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.pdf">[PDF]</a>
    *
    * @param n The number of integers to choose from.
    * @return A triple of randomly chosen integers from the interval [0, n).
@@ -559,10 +563,11 @@ public class EnhancedRandomGenerator implements RandomGenerator {
    *
    * <p>The runtime of this method is O(1), and it uses an algorithm described in:
    *
-   * <p>Vincent A. Cicirello. 2024. <a href="https://reports.cicirello.org/24/008/">Algorithms for
-   * Generating Small Random Samples. <a
-   * href="https://arxiv.org/abs/2405.12371">arXiv:2405.12371</a>, May 2024. <a
-   * href="https://reports.cicirello.org/24/008/ALG-24-008.pdf">[PDF]</a>
+   * <p>Vincent A. Cicirello. 2024. <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.html">Algorithms for Generating
+   * Small Random Samples.</a> <i>Software: Practice and Experience</i>, September 2024. doi:<a
+   * href="https://doi.org/10.1002/spe.3379">10.1002/spe.3379</a> <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.pdf">[PDF]</a>
    *
    * @param n The number of integers to choose from.
    * @param result An array to hold the pair that is generated. If result is null or if
@@ -581,10 +586,11 @@ public class EnhancedRandomGenerator implements RandomGenerator {
    *
    * <p>The runtime of this method is O(1), and it uses an algorithm described in:
    *
-   * <p>Vincent A. Cicirello. 2024. <a href="https://reports.cicirello.org/24/008/">Algorithms for
-   * Generating Small Random Samples. <a
-   * href="https://arxiv.org/abs/2405.12371">arXiv:2405.12371</a>, May 2024. <a
-   * href="https://reports.cicirello.org/24/008/ALG-24-008.pdf">[PDF]</a>
+   * <p>Vincent A. Cicirello. 2024. <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.html">Algorithms for Generating
+   * Small Random Samples.</a> <i>Software: Practice and Experience</i>, September 2024. doi:<a
+   * href="https://doi.org/10.1002/spe.3379">10.1002/spe.3379</a> <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.pdf">[PDF]</a>
    *
    * @param n The number of integers to choose from.
    * @return A pair of randomly chosen integers from the interval [0, n).
@@ -601,10 +607,11 @@ public class EnhancedRandomGenerator implements RandomGenerator {
    *
    * <p>The runtime of this method is O(1), and it uses an algorithm described in:
    *
-   * <p>Vincent A. Cicirello. 2024. <a href="https://reports.cicirello.org/24/008/">Algorithms for
-   * Generating Small Random Samples. <a
-   * href="https://arxiv.org/abs/2405.12371">arXiv:2405.12371</a>, May 2024. <a
-   * href="https://reports.cicirello.org/24/008/ALG-24-008.pdf">[PDF]</a>
+   * <p>Vincent A. Cicirello. 2024. <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.html">Algorithms for Generating
+   * Small Random Samples.</a> <i>Software: Practice and Experience</i>, September 2024. doi:<a
+   * href="https://doi.org/10.1002/spe.3379">10.1002/spe.3379</a> <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.pdf">[PDF]</a>
    *
    * @param n The number of integers to choose from.
    * @param result An array to hold the triple that is generated. If result is null or if
@@ -623,10 +630,11 @@ public class EnhancedRandomGenerator implements RandomGenerator {
    *
    * <p>The runtime of this method is O(1), and it uses an algorithm described in:
    *
-   * <p>Vincent A. Cicirello. 2024. <a href="https://reports.cicirello.org/24/008/">Algorithms for
-   * Generating Small Random Samples. <a
-   * href="https://arxiv.org/abs/2405.12371">arXiv:2405.12371</a>, May 2024. <a
-   * href="https://reports.cicirello.org/24/008/ALG-24-008.pdf">[PDF]</a>
+   * <p>Vincent A. Cicirello. 2024. <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.html">Algorithms for Generating
+   * Small Random Samples.</a> <i>Software: Practice and Experience</i>, September 2024. doi:<a
+   * href="https://doi.org/10.1002/spe.3379">10.1002/spe.3379</a> <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.pdf">[PDF]</a>
    *
    * @param n The number of integers to choose from.
    * @return A triple of randomly chosen integers from the interval [0, n).

--- a/src/main/java/org/cicirello/math/rand/RandomIndexer.java
+++ b/src/main/java/org/cicirello/math/rand/RandomIndexer.java
@@ -361,10 +361,11 @@ public final class RandomIndexer {
    *
    * <p>The runtime of this method is O(1), and it uses an algorithm described in:
    *
-   * <p>Vincent A. Cicirello. 2024. <a href="https://reports.cicirello.org/24/008/">Algorithms for
-   * Generating Small Random Samples. <a
-   * href="https://arxiv.org/abs/2405.12371">arXiv:2405.12371</a>, May 2024. <a
-   * href="https://reports.cicirello.org/24/008/ALG-24-008.pdf">[PDF]</a>
+   * <p>Vincent A. Cicirello. 2024. <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.html">Algorithms for Generating
+   * Small Random Samples.</a> <i>Software: Practice and Experience</i>, September 2024. doi:<a
+   * href="https://doi.org/10.1002/spe.3379">10.1002/spe.3379</a> <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.pdf">[PDF]</a>
    *
    * <p>This method uses ThreadLocalRandom as the pseudorandom number generator, and is thus safe,
    * and efficient (i.e., non-blocking), for use with threads.
@@ -385,10 +386,11 @@ public final class RandomIndexer {
    *
    * <p>The runtime of this method is O(1), and it uses an algorithm described in:
    *
-   * <p>Vincent A. Cicirello. 2024. <a href="https://reports.cicirello.org/24/008/">Algorithms for
-   * Generating Small Random Samples. <a
-   * href="https://arxiv.org/abs/2405.12371">arXiv:2405.12371</a>, May 2024. <a
-   * href="https://reports.cicirello.org/24/008/ALG-24-008.pdf">[PDF]</a>
+   * <p>Vincent A. Cicirello. 2024. <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.html">Algorithms for Generating
+   * Small Random Samples.</a> <i>Software: Practice and Experience</i>, September 2024. doi:<a
+   * href="https://doi.org/10.1002/spe.3379">10.1002/spe.3379</a> <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.pdf">[PDF]</a>
    *
    * @param n The number of integers to choose from.
    * @param result An array to hold the pair that is generated. If result is null or if
@@ -413,10 +415,11 @@ public final class RandomIndexer {
    *
    * <p>The runtime of this method is O(1), and it uses an algorithm described in:
    *
-   * <p>Vincent A. Cicirello. 2024. <a href="https://reports.cicirello.org/24/008/">Algorithms for
-   * Generating Small Random Samples. <a
-   * href="https://arxiv.org/abs/2405.12371">arXiv:2405.12371</a>, May 2024. <a
-   * href="https://reports.cicirello.org/24/008/ALG-24-008.pdf">[PDF]</a>
+   * <p>Vincent A. Cicirello. 2024. <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.html">Algorithms for Generating
+   * Small Random Samples.</a> <i>Software: Practice and Experience</i>, September 2024. doi:<a
+   * href="https://doi.org/10.1002/spe.3379">10.1002/spe.3379</a> <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.pdf">[PDF]</a>
    *
    * <p>This method uses ThreadLocalRandom as the pseudorandom number generator, and is thus safe,
    * and efficient (i.e., non-blocking), for use with threads.
@@ -435,10 +438,11 @@ public final class RandomIndexer {
    *
    * <p>The runtime of this method is O(1), and it uses an algorithm described in:
    *
-   * <p>Vincent A. Cicirello. 2024. <a href="https://reports.cicirello.org/24/008/">Algorithms for
-   * Generating Small Random Samples. <a
-   * href="https://arxiv.org/abs/2405.12371">arXiv:2405.12371</a>, May 2024. <a
-   * href="https://reports.cicirello.org/24/008/ALG-24-008.pdf">[PDF]</a>
+   * <p>Vincent A. Cicirello. 2024. <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.html">Algorithms for Generating
+   * Small Random Samples.</a> <i>Software: Practice and Experience</i>, September 2024. doi:<a
+   * href="https://doi.org/10.1002/spe.3379">10.1002/spe.3379</a> <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.pdf">[PDF]</a>
    *
    * @param n The number of integers to choose from.
    * @param gen Source of randomness.
@@ -457,10 +461,11 @@ public final class RandomIndexer {
    *
    * <p>The runtime of this method is O(1), and it uses an algorithm described in:
    *
-   * <p>Vincent A. Cicirello. 2024. <a href="https://reports.cicirello.org/24/008/">Algorithms for
-   * Generating Small Random Samples. <a
-   * href="https://arxiv.org/abs/2405.12371">arXiv:2405.12371</a>, May 2024. <a
-   * href="https://reports.cicirello.org/24/008/ALG-24-008.pdf">[PDF]</a>
+   * <p>Vincent A. Cicirello. 2024. <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.html">Algorithms for Generating
+   * Small Random Samples.</a> <i>Software: Practice and Experience</i>, September 2024. doi:<a
+   * href="https://doi.org/10.1002/spe.3379">10.1002/spe.3379</a> <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.pdf">[PDF]</a>
    *
    * <p>This method uses ThreadLocalRandom as the pseudorandom number generator, and is thus safe,
    * and efficient (i.e., non-blocking), for use with threads.
@@ -481,10 +486,11 @@ public final class RandomIndexer {
    *
    * <p>The runtime of this method is O(1), and it uses an algorithm described in:
    *
-   * <p>Vincent A. Cicirello. 2024. <a href="https://reports.cicirello.org/24/008/">Algorithms for
-   * Generating Small Random Samples. <a
-   * href="https://arxiv.org/abs/2405.12371">arXiv:2405.12371</a>, May 2024. <a
-   * href="https://reports.cicirello.org/24/008/ALG-24-008.pdf">[PDF]</a>
+   * <p>Vincent A. Cicirello. 2024. <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.html">Algorithms for Generating
+   * Small Random Samples.</a> <i>Software: Practice and Experience</i>, September 2024. doi:<a
+   * href="https://doi.org/10.1002/spe.3379">10.1002/spe.3379</a> <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.pdf">[PDF]</a>
    *
    * @param n The number of integers to choose from.
    * @param result An array to hold the pair that is generated. If result is null or if
@@ -516,10 +522,11 @@ public final class RandomIndexer {
    *
    * <p>The runtime of this method is O(1), and it uses an algorithm described in:
    *
-   * <p>Vincent A. Cicirello. 2024. <a href="https://reports.cicirello.org/24/008/">Algorithms for
-   * Generating Small Random Samples. <a
-   * href="https://arxiv.org/abs/2405.12371">arXiv:2405.12371</a>, May 2024. <a
-   * href="https://reports.cicirello.org/24/008/ALG-24-008.pdf">[PDF]</a>
+   * <p>Vincent A. Cicirello. 2024. <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.html">Algorithms for Generating
+   * Small Random Samples.</a> <i>Software: Practice and Experience</i>, September 2024. doi:<a
+   * href="https://doi.org/10.1002/spe.3379">10.1002/spe.3379</a> <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.pdf">[PDF]</a>
    *
    * <p>This method uses ThreadLocalRandom as the pseudorandom number generator, and is thus safe,
    * and efficient (i.e., non-blocking), for use with threads.
@@ -538,10 +545,11 @@ public final class RandomIndexer {
    *
    * <p>The runtime of this method is O(1), and it uses an algorithm described in:
    *
-   * <p>Vincent A. Cicirello. 2024. <a href="https://reports.cicirello.org/24/008/">Algorithms for
-   * Generating Small Random Samples. <a
-   * href="https://arxiv.org/abs/2405.12371">arXiv:2405.12371</a>, May 2024. <a
-   * href="https://reports.cicirello.org/24/008/ALG-24-008.pdf">[PDF]</a>
+   * <p>Vincent A. Cicirello. 2024. <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.html">Algorithms for Generating
+   * Small Random Samples.</a> <i>Software: Practice and Experience</i>, September 2024. doi:<a
+   * href="https://doi.org/10.1002/spe.3379">10.1002/spe.3379</a> <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.pdf">[PDF]</a>
    *
    * @param n The number of integers to choose from.
    * @param gen Source of randomness.
@@ -565,10 +573,11 @@ public final class RandomIndexer {
    *
    * <p>The runtime of this method is O(1), and it uses an algorithm described in:
    *
-   * <p>Vincent A. Cicirello. 2024. <a href="https://reports.cicirello.org/24/008/">Algorithms for
-   * Generating Small Random Samples. <a
-   * href="https://arxiv.org/abs/2405.12371">arXiv:2405.12371</a>, May 2024. <a
-   * href="https://reports.cicirello.org/24/008/ALG-24-008.pdf">[PDF]</a>
+   * <p>Vincent A. Cicirello. 2024. <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.html">Algorithms for Generating
+   * Small Random Samples.</a> <i>Software: Practice and Experience</i>, September 2024. doi:<a
+   * href="https://doi.org/10.1002/spe.3379">10.1002/spe.3379</a> <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.pdf">[PDF]</a>
    *
    * <p>This method uses ThreadLocalRandom as the pseudorandom number generator, and is thus safe,
    * and efficient (i.e., non-blocking), for use with threads.
@@ -590,10 +599,11 @@ public final class RandomIndexer {
    *
    * <p>The runtime of this method is O(1), and it uses an algorithm described in:
    *
-   * <p>Vincent A. Cicirello. 2024. <a href="https://reports.cicirello.org/24/008/">Algorithms for
-   * Generating Small Random Samples. <a
-   * href="https://arxiv.org/abs/2405.12371">arXiv:2405.12371</a>, May 2024. <a
-   * href="https://reports.cicirello.org/24/008/ALG-24-008.pdf">[PDF]</a>
+   * <p>Vincent A. Cicirello. 2024. <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.html">Algorithms for Generating
+   * Small Random Samples.</a> <i>Software: Practice and Experience</i>, September 2024. doi:<a
+   * href="https://doi.org/10.1002/spe.3379">10.1002/spe.3379</a> <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.pdf">[PDF]</a>
    *
    * @param n The number of integers to choose from.
    * @param result An array to hold the pair that is generated. If result is null or if
@@ -621,10 +631,11 @@ public final class RandomIndexer {
    *
    * <p>The runtime of this method is O(1), and it uses an algorithm described in:
    *
-   * <p>Vincent A. Cicirello. 2024. <a href="https://reports.cicirello.org/24/008/">Algorithms for
-   * Generating Small Random Samples. <a
-   * href="https://arxiv.org/abs/2405.12371">arXiv:2405.12371</a>, May 2024. <a
-   * href="https://reports.cicirello.org/24/008/ALG-24-008.pdf">[PDF]</a>
+   * <p>Vincent A. Cicirello. 2024. <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.html">Algorithms for Generating
+   * Small Random Samples.</a> <i>Software: Practice and Experience</i>, September 2024. doi:<a
+   * href="https://doi.org/10.1002/spe.3379">10.1002/spe.3379</a> <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.pdf">[PDF]</a>
    *
    * <p>This method uses ThreadLocalRandom as the pseudorandom number generator, and is thus safe,
    * and efficient (i.e., non-blocking), for use with threads.
@@ -644,10 +655,11 @@ public final class RandomIndexer {
    *
    * <p>The runtime of this method is O(1), and it uses an algorithm described in:
    *
-   * <p>Vincent A. Cicirello. 2024. <a href="https://reports.cicirello.org/24/008/">Algorithms for
-   * Generating Small Random Samples. <a
-   * href="https://arxiv.org/abs/2405.12371">arXiv:2405.12371</a>, May 2024. <a
-   * href="https://reports.cicirello.org/24/008/ALG-24-008.pdf">[PDF]</a>
+   * <p>Vincent A. Cicirello. 2024. <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.html">Algorithms for Generating
+   * Small Random Samples.</a> <i>Software: Practice and Experience</i>, September 2024. doi:<a
+   * href="https://doi.org/10.1002/spe.3379">10.1002/spe.3379</a> <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.pdf">[PDF]</a>
    *
    * @param n The number of integers to choose from.
    * @param gen Source of randomness.
@@ -655,15 +667,11 @@ public final class RandomIndexer {
    * @throws IllegalArgumentException if n &lt; 2.
    */
   public static IndexPair nextSortedIntPair(int n, RandomGenerator gen) {
-    final int i = nextInt(n, gen);
-    final int j = nextInt(n - 1, gen);
-    if (i < j) {
-      return new IndexPair(i, j);
-    } else if (i == j) {
-      return new IndexPair(i, n - 1);
-    } else {
-      return new IndexPair(j, i);
+    final IndexPair pair = nextIntPair(n, gen);
+    if (pair.i() < pair.j()) {
+      return pair;
     }
+    return new IndexPair(pair.j(), pair.i());
   }
 
   /**
@@ -673,10 +681,11 @@ public final class RandomIndexer {
    *
    * <p>The runtime of this method is O(1), and it uses an algorithm described in:
    *
-   * <p>Vincent A. Cicirello. 2024. <a href="https://reports.cicirello.org/24/008/">Algorithms for
-   * Generating Small Random Samples. <a
-   * href="https://arxiv.org/abs/2405.12371">arXiv:2405.12371</a>, May 2024. <a
-   * href="https://reports.cicirello.org/24/008/ALG-24-008.pdf">[PDF]</a>
+   * <p>Vincent A. Cicirello. 2024. <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.html">Algorithms for Generating
+   * Small Random Samples.</a> <i>Software: Practice and Experience</i>, September 2024. doi:<a
+   * href="https://doi.org/10.1002/spe.3379">10.1002/spe.3379</a> <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.pdf">[PDF]</a>
    *
    * <p>This method uses ThreadLocalRandom as the pseudorandom number generator, and is thus safe,
    * and efficient (i.e., non-blocking), for use with threads.
@@ -698,10 +707,11 @@ public final class RandomIndexer {
    *
    * <p>The runtime of this method is O(1), and it uses an algorithm described in:
    *
-   * <p>Vincent A. Cicirello. 2024. <a href="https://reports.cicirello.org/24/008/">Algorithms for
-   * Generating Small Random Samples. <a
-   * href="https://arxiv.org/abs/2405.12371">arXiv:2405.12371</a>, May 2024. <a
-   * href="https://reports.cicirello.org/24/008/ALG-24-008.pdf">[PDF]</a>
+   * <p>Vincent A. Cicirello. 2024. <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.html">Algorithms for Generating
+   * Small Random Samples.</a> <i>Software: Practice and Experience</i>, September 2024. doi:<a
+   * href="https://doi.org/10.1002/spe.3379">10.1002/spe.3379</a> <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.pdf">[PDF]</a>
    *
    * @param n The number of integers to choose from.
    * @param result An array to hold the pair that is generated. If result is null or if
@@ -723,10 +733,11 @@ public final class RandomIndexer {
    *
    * <p>The runtime of this method is O(1), and it uses an algorithm described in:
    *
-   * <p>Vincent A. Cicirello. 2024. <a href="https://reports.cicirello.org/24/008/">Algorithms for
-   * Generating Small Random Samples. <a
-   * href="https://arxiv.org/abs/2405.12371">arXiv:2405.12371</a>, May 2024. <a
-   * href="https://reports.cicirello.org/24/008/ALG-24-008.pdf">[PDF]</a>
+   * <p>Vincent A. Cicirello. 2024. <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.html">Algorithms for Generating
+   * Small Random Samples.</a> <i>Software: Practice and Experience</i>, September 2024. doi:<a
+   * href="https://doi.org/10.1002/spe.3379">10.1002/spe.3379</a> <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.pdf">[PDF]</a>
    *
    * <p>This method uses ThreadLocalRandom as the pseudorandom number generator, and is thus safe,
    * and efficient (i.e., non-blocking), for use with threads.
@@ -746,10 +757,11 @@ public final class RandomIndexer {
    *
    * <p>The runtime of this method is O(1), and it uses an algorithm described in:
    *
-   * <p>Vincent A. Cicirello. 2024. <a href="https://reports.cicirello.org/24/008/">Algorithms for
-   * Generating Small Random Samples. <a
-   * href="https://arxiv.org/abs/2405.12371">arXiv:2405.12371</a>, May 2024. <a
-   * href="https://reports.cicirello.org/24/008/ALG-24-008.pdf">[PDF]</a>
+   * <p>Vincent A. Cicirello. 2024. <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.html">Algorithms for Generating
+   * Small Random Samples.</a> <i>Software: Practice and Experience</i>, September 2024. doi:<a
+   * href="https://doi.org/10.1002/spe.3379">10.1002/spe.3379</a> <a
+   * href="https://www.cicirello.org/publications/cicirello2024spe.pdf">[PDF]</a>
    *
    * @param n The number of integers to choose from.
    * @param gen The source of randomness.
@@ -757,16 +769,8 @@ public final class RandomIndexer {
    * @throws IllegalArgumentException if n &lt; 3.
    */
   public static IndexTriple nextSortedIntTriple(int n, RandomGenerator gen) {
-    final int i = nextInt(n, gen);
-    final int j = nextInt(n - 1, gen);
-    int k = nextInt(n - 2, gen);
-    if (j == i) {
-      return IndexTriple.sorted(i, k == i ? n - 2 : k, n - 1);
-    }
-    if (k == j) {
-      k = n - 2;
-    }
-    return IndexTriple.sorted(i, j, k == i ? n - 1 : k);
+    final IndexTriple triple = nextIntTriple(n, gen);
+    return IndexTriple.sorted(triple.i(), triple.j(), triple.k());
   }
 
   /**


### PR DESCRIPTION
## Summary
Update documentation to reference the SPE 2024 article. Additionally, a recent update to the javadoc plugin for Maven seems to have changed output directory for the documentation. This PR also includes an update to the docs GitHub workflow to ensure doc website is updated correctly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
